### PR TITLE
Add preferences variable to store Environment Path

### DIFF
--- a/functions/Get-PasswordStateEnvironment.ps1
+++ b/functions/Get-PasswordStateEnvironment.ps1
@@ -26,7 +26,11 @@ function Get-PasswordStateEnvironment {
         }
         try {
             # Get Profile path
-            $profilepath = $path
+            if ($Script:Preferences.Path -ne '') {
+                $profilepath=$Script:Preferences.Path
+            } else {
+                $profilepath = $path
+            }
             # Read in the password state environment json config file.
             $content = Get-Content "$($profilepath)\passwordstate.json" -ErrorAction Stop
         }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -95,6 +95,7 @@ function Set-PasswordStateEnvironment {
     end {
         if ($PSCmdlet.ShouldProcess("$($profilepath)\passwordstate.json")) {
             $json | Out-File "$($profilepath)\passwordstate.json"
+            $Script:Preferences.Path=$profilepath
         }
     }
 }

--- a/passwordstate-management.psm1
+++ b/passwordstate-management.psm1
@@ -79,3 +79,6 @@ if ($importIndividualFiles)
 #region Load compiled code
 "<compile code into here>"
 #endregion Load compiled code
+$Script:Preferences=[PSCustomObject]@{
+	Path = ''
+}


### PR DESCRIPTION
By using a module-scoped preference custom object,
I ensure the contents remains hidden from the powershell session.
Whenever Get-PasswordStateEnvironment is called,
it will look if the preference has been set and act accordingly

Fixes #81