### PR TITLE
Move Class definition creation to preimport

### DIFF
--- a/functions/Get-PasswordStatePassword.ps1
+++ b/functions/Get-PasswordStatePassword.ps1
@@ -33,9 +33,6 @@
     )
 
     Begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
-        Add-Type -AssemblyName System.Web
-        # Initalize output Array
     }
 
     Process {

--- a/functions/Get-PasswordStatePasswordHistory.ps1
+++ b/functions/Get-PasswordStatePasswordHistory.ps1
@@ -11,7 +11,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
         $output = @()
     }
 

--- a/functions/New-PasswordStateDocument.ps1
+++ b/functions/New-PasswordStateDocument.ps1
@@ -13,7 +13,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
         $output = @()
     }
 

--- a/functions/New-PasswordStateFolder.ps1
+++ b/functions/New-PasswordStateFolder.ps1
@@ -12,7 +12,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
     }
 
     process {

--- a/functions/New-PasswordStateList.ps1
+++ b/functions/New-PasswordStateList.ps1
@@ -12,7 +12,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
     }
     process {
         # Build the Custom object to convert to json and send to the api.

--- a/functions/New-PasswordStatePassword.ps1
+++ b/functions/New-PasswordStatePassword.ps1
@@ -27,7 +27,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
         # Check to see if the requested password entry exists before continuing.
         try {
             $result = Get-PasswordStatePassword -title "$title" -username $username -ErrorAction stop

--- a/functions/Save-PasswordStateDocument.ps1
+++ b/functions/Save-PasswordStateDocument.ps1
@@ -11,7 +11,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
         $output = @()
     }
 

--- a/functions/Update-PasswordStatePassword.ps1
+++ b/functions/Update-PasswordStatePassword.ps1
@@ -28,7 +28,6 @@
     )
 
     begin {
-        . "$(Get-NativePath -PathAsStringArray "$PSScriptroot","PasswordStateClass.ps1")"
     }
 
     process {

--- a/internal/scripts/preimport.ps1
+++ b/internal/scripts/preimport.ps1
@@ -2,3 +2,5 @@
 
 # Load the strings used in messages
 . Import-ModuleFile -Path "$($script:ModuleRoot)\internal\scripts\strings.ps1"
+. Import-ModuleFile -Path "$($Script:ModuleRoot)\internal\functions\PasswordStateClass.ps1"
+Add-Type -AssemblyName System.Web


### PR DESCRIPTION
Almost all functions that rely on the custom-defined
PowerShell Classes
(EncryptedPassword, PasswordResult and PasswordHistory)
constantly call recreate those classes, which causes overhead.
By moving that creation to the Preimport.ps1,
they are available in the module as soon as it is imported.
Therefore all references in other files can be removed.

Fixes: #83