### PR TITLE
108 set plain text passwords

### DIFF
--- a/functions/Get-PasswordStatePassword.ps1
+++ b/functions/Get-PasswordStatePassword.ps1
@@ -33,6 +33,7 @@
     )
 
     Begin {
+        $PWSProfile = Get-PasswordStateEnvironment -path $Script:Preferences.Path
     }
 
     Process {
@@ -100,21 +101,13 @@
             }
         }
         Try {
-            $obj = Get-PasswordStateResource -URI $uri @parms  -Method GET
-            foreach ($i in $obj) {
-                [PasswordResult]$i = $i
-                $i.Password = [EncryptedPassword]$i.Password
-                switch ($global:PasswordStateShowPasswordsPlainText) {
-                    True {
-                        $i.DecryptPassword()
-                    }
-                    Default {
-
-                    }
+            foreach ($PWSEntry in (Get-PasswordStateResource -URI $uri @parms  -Method GET)) {
+                [PasswordResult]$PWSEntry = $PWSEntry
+                if(!$PWSProfile.PasswordsInPlainText) {
+                    $PWSEntry.Password = [EncryptedPassword]$PWSEntry.Password
                 }
-                Write-Output $i
+                $PWSEntry
             }
-
         }
         Catch {
             Throw $_.Exception

--- a/functions/New-PasswordStatePassword.ps1
+++ b/functions/New-PasswordStatePassword.ps1
@@ -69,6 +69,36 @@
             if ($GeneratePassword) {
                 $body | add-member -notepropertyname GeneratePassword -NotePropertyValue $true
             }
+            if ($GenericField1 -and !([string]::IsNullOrEmpty($GenericField1))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField1
+            }
+            if ($GenericField2 -and !([string]::IsNullOrEmpty($GenericField2))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField2
+            }
+            if ($GenericField3 -and !([string]::IsNullOrEmpty($GenericField3))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField3
+            }
+            if ($GenericField4 -and !([string]::IsNullOrEmpty($GenericField4))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField4
+            }
+            if ($GenericField5 -and !([string]::IsNullOrEmpty($GenericField5))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField5
+            }
+            if ($GenericField6 -and !([string]::IsNullOrEmpty($GenericField6))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField6
+            }
+            if ($GenericField7 -and !([string]::IsNullOrEmpty($GenericField7))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField7
+            }
+            if ($GenericField8 -and !([string]::IsNullOrEmpty($GenericField8))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField8
+            }
+            if ($GenericField9 -and !([string]::IsNullOrEmpty($GenericField9))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField9
+            }
+            if ($GenericField10 -and !([string]::IsNullOrEmpty($GenericField10))) {
+                $body | Add-Member -NotePropertyName "GenericField1" -NotePropertyValue $GenericField10
+            }
             if ($PSCmdlet.ShouldProcess("PasswordList:$passwordListID Title:$title Username:$username")) {
                 [PasswordResult]$output = New-PasswordStateResource -uri "/api/passwords" -body "$($body|convertto-json)"
                 foreach ($i in $output) {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -38,36 +38,37 @@
 
     process {
         # Build the custom object to be converted to JSON. Set APIKey as WindowsAuth if we are to use windows authentication.
-        $json = [PSCustomObject]@{
-            TimeoutSeconds = 60
-            Baseuri = $Baseuri
-            Apikey = switch ($AuthType) {
-                WindowsIntegrated { "" }
-                WindowsCustom {
-                    [pscustomobject]@{
-                        "username" = $customcredentials.UserName
-                        "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
-                    }
-                }
-                APIKey {
-                    ($Apikey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
-
+        $JsonApiKey = switch ($AuthType) {
+            WindowsIntegrated { "" }
+            WindowsCustom {
+                @{
+                    "username" = $customcredentials.UserName
+                    "Password" = ($customcredentials.Password | ConvertFrom-SecureString)
                 }
             }
+            APIKey {
+                ($Apikey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
+
+            }
+        }
+        $json = @{
+            TimeoutSeconds = 60
+            Baseuri = $Baseuri
+            Apikey = $JsonApiKey
             "AuthType" = $AuthType
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
-                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+                $json['PasswordsInPlainText'] = $SetPlainTextPasswords
             } else {
-                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
+                $json['PasswordsInPlainText'] = $false
             }
         } else {
-            $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+            $json['PasswordsInPlainText'] = $SetPlainTextPasswords
         }
 
         if ($PasswordGeneratorAPIkey){
-            $json | Add-Member -NotePropertyName 'PasswordGeneratorAPIKey' -NotePropertyValue ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
+            $json['PasswordGeneratorAPIKey'] = ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
         }
         $json = $json | ConvertTo-Json
     }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -59,7 +59,7 @@
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
                 $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
-            } else { 
+            } else {
                 $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
             }
         } else {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -3,7 +3,7 @@
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlaintextForPassword', '', Justification = 'no password')]
     [CmdletBinding(DefaultParameterSetName = "Two", SupportsShouldProcess, ConfirmImpact="High")]
     param (
-        [Parameter(ValueFromPipelineByPropertyName,Mandatory = $true)][string]$Baseuri,
+        [Parameter(ValueFromPipelineByPropertyName,Mandatory = $true)][Alias('Baseuri')][uri]$Uri,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'One')][string]$Apikey,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'One')][string]$PasswordGeneratorAPIkey,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'Two')][switch]$WindowsAuthOnly,
@@ -13,14 +13,6 @@
     )
 
     begin {
-        # ensure the uri is always in the correct format.
-        $uri = ([uri]$Baseuri)
-        if ($uri.IsDefaultPort -eq $true){
-            $Baseuri = '{0}://{1}' -f $uri.Scheme,$uri.DnsSafeHost
-        }
-        Else {
-            $Baseuri = '{0}://{1}:{2}' -f $uri.Scheme,$uri.Host,$uri.Port
-        }
         if ($WindowsAuthOnly -eq $true) {
             $AuthType = "WindowsIntegrated"
         }
@@ -53,7 +45,7 @@
         }
         $json = @{
             TimeoutSeconds = 60
-            Baseuri = $Baseuri
+            Baseuri = $Uri -replace '/$',''
             Apikey = $JsonApiKey
             AuthType = $AuthType
         }

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -55,7 +55,7 @@
             TimeoutSeconds = 60
             Baseuri = $Baseuri
             Apikey = $JsonApiKey
-            "AuthType" = $AuthType
+            AuthType = $AuthType
         }
         if ($SetPlainTextPasswords) {
             if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {

--- a/functions/Set-PasswordStateEnvironment.ps1
+++ b/functions/Set-PasswordStateEnvironment.ps1
@@ -1,15 +1,15 @@
 ﻿function Set-PasswordStateEnvironment {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingConvertToSecureStringWithPlainText', '', Justification = 'all passwords stored encrypted')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlaintextForPassword', '', Justification = 'no password')]
-    [CmdletBinding(DefaultParameterSetName = "Two", SupportsShouldProcess = $true)]
+    [CmdletBinding(DefaultParameterSetName = "Two", SupportsShouldProcess, ConfirmImpact="High")]
     param (
         [Parameter(ValueFromPipelineByPropertyName,Mandatory = $true)][string]$Baseuri,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'One')][string]$Apikey,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'One')][string]$PasswordGeneratorAPIkey,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'Two')][switch]$WindowsAuthOnly,
         [Parameter(ValueFromPipelineByPropertyName,ParameterSetName = 'Three')][pscredential]$customcredentials,
-        [Parameter(ValueFromPipelineByPropertyName,Mandatory = $false)][string]$path = [Environment]::GetFolderPath('UserProfile')
-
+        [Parameter(ValueFromPipelineByPropertyName,Mandatory = $false)][string]$path = [Environment]::GetFolderPath('UserProfile'),
+        [Parameter()][bool]$SetPlainTextPasswords = $False
     )
 
     begin {
@@ -38,13 +38,11 @@
 
     process {
         # Build the custom object to be converted to JSON. Set APIKey as WindowsAuth if we are to use windows authentication.
-        $json = [pscustomobject] @{
-            "TimeoutSeconds" = 60
-            "Baseuri"  = $Baseuri
-            "Apikey"   = switch ($AuthType) {
-                WindowsIntegrated {
-                    ""
-                }
+        $json = [PSCustomObject]@{
+            TimeoutSeconds = 60
+            Baseuri = $Baseuri
+            Apikey = switch ($AuthType) {
+                WindowsIntegrated { "" }
                 WindowsCustom {
                     [pscustomobject]@{
                         "username" = $customcredentials.UserName
@@ -58,16 +56,24 @@
             }
             "AuthType" = $AuthType
         }
+        if ($SetPlainTextPasswords) {
+            if ($PSCmdlet.ShouldProcess('Allow passwords to be returned in plain text')) {
+                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+            } else { 
+                $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $false
+            }
+        } else {
+            $json | Add-Member -NotePropertyName 'PasswordsInPlainText' -NotePropertyValue $SetPlainTextPasswords
+        }
+
         if ($PasswordGeneratorAPIkey){
-            $json | Add-Member -MemberType NoteProperty -Name PasswordGeneratorAPIKey -Value ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
+            $json | Add-Member -NotePropertyName 'PasswordGeneratorAPIKey' -NotePropertyValue ($PasswordGeneratorAPIkey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString)
         }
         $json = $json | ConvertTo-Json
     }
 
     end {
-        if ($PSCmdlet.ShouldProcess("$($profilepath)\passwordstate.json")) {
-            $json | Out-File "$($profilepath)\passwordstate.json"
-            $Script:Preferences.Path=$profilepath
-        }
+        $json | Out-File "$($profilepath)\passwordstate.json"
+        $Script:Preferences.Path=$profilepath
     }
 }

--- a/internal/functions/Get-PSCustomObject.ps1
+++ b/internal/functions/Get-PSCustomObject.ps1
@@ -14,20 +14,22 @@
         [Parameter(ValueFromPipelineByPropertyName, ValueFromPipeline, Mandatory = $false)]
         [switch]$Stable
     )
-    if ($Sort) {
-        # Create a temporary new ordered hashtable
-        $ObjectSorted = [ordered]@{ }
-        # Get all properties from the given InputObject, sort it by name and add each property to the temporary created ordered hashtable
-        Get-Member -Type NoteProperty -InputObject $InputObject | Sort-Object -Unique:$Unique -Descending:$Descending -CaseSensitive:$CaseSensitive -Stable:$Stable -Property Name | ForEach-Object { $ObjectSorted[$_.Name] = $InputObject.$($_.Name) }
-        # Create a new PSCustomObject that will receive the sorted properties from the hashtable
-        $OutputObject = New-Object PSCustomObject
-        # Add each property the the newly created PSCustomObject
-        Add-Member -InputObject $OutputObject -NotePropertyMembers $ObjectSorted
+    process {
+        if ($Sort) {
+            # Create a temporary new ordered hashtable
+            $ObjectSorted = [ordered]@{ }
+            # Get all properties from the given InputObject, sort it by name and add each property to the temporary created ordered hashtable
+            Get-Member -Type NoteProperty -InputObject $InputObject | Sort-Object -Unique:$Unique -Descending:$Descending -CaseSensitive:$CaseSensitive -Stable:$Stable -Property Name | ForEach-Object { $ObjectSorted[$_.Name] = $InputObject.$($_.Name) }
+            # Create a new PSCustomObject that will receive the sorted properties from the hashtable
+            $OutputObject = New-Object PSCustomObject
+            # Add each property the the newly created PSCustomObject
+            Add-Member -InputObject $OutputObject -NotePropertyMembers $ObjectSorted
 
-        # return the sorted object
-        return $OutputObject
-    }
-    else {
-        return $InputObject
+            # return the sorted object
+            return $OutputObject
+        }
+        else {
+            return $InputObject
+        }
     }
 }

--- a/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
+++ b/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope 'PasswordState-Management' {
         BeforeAll {
             $FunctionName='Set-PasswordStateEnvironment'
             $ParameterTestCases=@(
-                 @{ParameterName='BaseUri';Mandatory='True';ParameterSetName='__AllParameterSets'}
+                 @{ParameterName='Uri';Mandatory='True';ParameterSetName='__AllParameterSets'}
                 ,@{ParameterName='ApiKey';Mandatory='False';ParameterSetName='One'}
                 ,@{ParameterName='PasswordGeneratorAPIkey';Mandatory='False';ParameterSetName='One'}
                 ,@{ParameterName='WindowsAuthOnly';Mandatory='False';ParameterSetName='Two'}
@@ -15,6 +15,11 @@ InModuleScope 'PasswordState-Management' {
                 ,@{ParameterName='SetPlainTextPasswords';Mandatory='False';ParameterSetName='__AllParameterSets'}
             )
             $AuthTestCases=@(
+                @{Uri='https://norealurl1.local'}
+                @{Uri='https://norealurl2.local'}
+                @{Uri='https://norealurl3.local'}
+            )
+            $BaseUriAuthTestCases=@(
                 @{Baseuri='https://norealurl1.local'}
                 @{Baseuri='https://norealurl2.local'}
                 @{Baseuri='https://norealurl3.local'}
@@ -41,57 +46,72 @@ InModuleScope 'PasswordState-Management' {
             }
         }
         Context 'Unit testing with api' {
-            It 'should throw an error for "<baseuri>" when no apikey is provided' -TestCases $AuthTestCases {
-                param($Baseuri)
-                { Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -ErrorAction Stop } | Should -throw
+            It 'should throw an error for "<Uri>" when no apikey is provided' -TestCases $AuthTestCases {
+                param($Uri)
+                { Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -ErrorAction Stop } | Should -throw
             }
-            It 'Should verify if a json file is written and Baseuri contains <baseuri>' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -Apikey $apikey -path $ProfilePath
-                (Get-Content $ProfileFile | ConvertFrom-Json).Baseuri | should -be $Baseuri
+            It 'Should verify if a json file is written and Uri contains <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -Apikey $apikey -path $ProfilePath
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Uri
             }
-            It 'Should verify if a json file is written and apikey is not empty for <baseuri>' -TestCases $AuthTestCases {
+            It 'Should verify if a json file is written and Baseuri contains <Baseuri>' -TestCases $BaseUriAuthTestCases {
                 param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -Apikey $apikey -path $ProfilePath
+                Set-PasswordStateEnvironment -BaseUri $Baseuri -Apikey $apikey -path $ProfilePath
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Baseuri
+            }
+            It 'Should verify if a json file is written and apikey is not empty for <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -Apikey $apikey -path $ProfilePath
                 (Get-Content $ProfileFile | ConvertFrom-Json).apikey | should -Not -BeNullOrEmpty
             }
-            It 'Should verify if a json file is written and AuthType is exactly "APIKey" for <baseuri>' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -Apikey $apikey -path $ProfilePath
+            It 'Should verify if a json file is written and AuthType is exactly "APIKey" for <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -Apikey $apikey -path $ProfilePath
                 (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | Should -BeExactly 'APIKey'
             }
         }
         Context 'Unit testing with Windows Authentication' {
-            It 'should verify if a json file is witten and Baseuri contains <baseuri>' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -WindowsAuthOnly
-                (Get-Content $ProfileFile | ConvertFrom-Json).Baseuri | should -be $Baseuri
+            It 'should verify if a json file is witten and BaseUri contains <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -WindowsAuthOnly
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Uri
             }
-            It 'Should verify if a json file is written and apikey is empty for <baseuri>' -TestCases $AuthTestCases {
+            It 'should verify if a json file is witten and BaseUri contains <Baseuri>' -TestCases $BaseUriAuthTestCases {
                 param($Baseuri)
                 Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -WindowsAuthOnly
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Baseuri
+            }
+            It 'Should verify if a json file is written and apikey is empty for <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -WindowsAuthOnly
                 (Get-Content $ProfileFile | ConvertFrom-Json).apikey | should -BeNullOrEmpty
             }
-            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <baseuri>' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -WindowsAuthOnly
+            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -WindowsAuthOnly
                 (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | should -BeExactly "WindowsIntegrated"
             }
         }
         Context 'Unit testing with Windows Custom Credential' {
-            It 'should verify if a json file is witten and Baseuri contains <baseuri>' -TestCases $AuthTestCases {
+            It 'should verify if a json file is witten and Uri contains <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Uri
+            }
+            It 'should verify if a json file is witten and Baseuri contains <Baseuri>' -TestCases $BaseuriAuthTestCases {
                 param($Baseuri)
                 Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
-                (Get-Content $ProfileFile | ConvertFrom-Json).Baseuri | should -be $Baseuri
+                (Get-Content $ProfileFile | ConvertFrom-Json).BaseUri | should -be $Baseuri
             }
             It 'Should verify if a json file is written and apikey has a credential' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
                 (Get-Content $ProfileFile | ConvertFrom-Json).apikey.username | should -BeExactly $UserName
             }
-            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <baseuri>' -TestCases $AuthTestCases {
-                param($Baseuri)
-                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <Uri>' -TestCases $AuthTestCases {
+                param($Uri)
+                Set-PasswordStateEnvironment -Uri $Uri -path $ProfilePath -customcredentials $Credential
                 (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | should -BeExactly "WindowsCustom"
             }
         }

--- a/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
+++ b/tests/functions/Set-PasswordStateEnvironment.Tests.ps1
@@ -12,6 +12,7 @@ InModuleScope 'PasswordState-Management' {
                 ,@{ParameterName='WindowsAuthOnly';Mandatory='False';ParameterSetName='Two'}
                 ,@{ParameterName='customcredentials';Mandatory='False';ParameterSetName='Three'}
                 ,@{ParameterName='Path';Mandatory='False';ParameterSetName='__AllParameterSets'}
+                ,@{ParameterName='SetPlainTextPasswords';Mandatory='False';ParameterSetName='__AllParameterSets'}
             )
             $AuthTestCases=@(
                 @{Baseuri='https://norealurl1.local'}
@@ -19,7 +20,8 @@ InModuleScope 'PasswordState-Management' {
                 @{Baseuri='https://norealurl3.local'}
             )
             $apiKey='somekey'
-            $Credential=[pscredential]::new('user',(ConvertTo-SecureString -AsPlainText -Force -String 'pass'))
+            $UserName = 'user'
+            $Credential=[pscredential]::new( $UserName ,(ConvertTo-SecureString -AsPlainText -Force -String 'pass'))
             $ProfilePath='TestDrive:\'
             $ProfileFile="$($ProfilePath)\passwordstate.json"
         }
@@ -74,6 +76,23 @@ InModuleScope 'PasswordState-Management' {
                 param($Baseuri)
                 Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -WindowsAuthOnly
                 (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | should -BeExactly "WindowsIntegrated"
+            }
+        }
+        Context 'Unit testing with Windows Custom Credential' {
+            It 'should verify if a json file is witten and Baseuri contains <baseuri>' -TestCases $AuthTestCases {
+                param($Baseuri)
+                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+                (Get-Content $ProfileFile | ConvertFrom-Json).Baseuri | should -be $Baseuri
+            }
+            It 'Should verify if a json file is written and apikey has a credential' -TestCases $AuthTestCases {
+                param($Baseuri)
+                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+                (Get-Content $ProfileFile | ConvertFrom-Json).apikey.username | should -BeExactly $UserName
+            }
+            It 'Should verify if a json file is written and AuthType is exactly "WindowsIntegrated" for <baseuri>' -TestCases $AuthTestCases {
+                param($Baseuri)
+                Set-PasswordStateEnvironment -Baseuri $Baseuri -path $ProfilePath -customcredentials $Credential
+                (Get-Content $ProfileFile | ConvertFrom-Json).AuthType | should -BeExactly "WindowsCustom"
             }
         }
     }


### PR DESCRIPTION
This PR adds the ability to allow the user of the module to get the passwords from Passwordstate received in clear text, rather than in an encrypted form.

List of changes:

* Added option "SetPlainTextPasswords" in Set-PasswordStateEnvironment
* Removed PSCustomObject to simplify the function
* Standardized the 'Uri' behavior in the module
* Correct unused variable warning in New-PasswordStatePassword

Fixes #108