### PR TITLE
Double tests with profile presence

### DIFF
--- a/tests/functions/Get-PasswordStateFolder.Tests.ps1
+++ b/tests/functions/Get-PasswordStateFolder.Tests.ps1
@@ -61,6 +61,87 @@ InModuleScope 'Passwordstate-Management' {
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).Mandatory)" | Should -be $mandatory
             }
         }
+        Context 'Unit tests with existing apikey profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=$APIKey;AuthType="APIKey"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return 6 Folders when no parameters are used' {
+                (Get-PasswordStateFolder).Count | Should -BeExactly 6
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should return <FolderCount> for parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $FolderCount)
+                ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count | Should -BeExactly $FolderCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $FolderCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+        Context 'Unit tests with existing winapi profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey="";AuthType="WindowsIntegrated"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return 6 Folders when no parameters are used' {
+                (Get-PasswordStateFolder).Count | Should -BeExactly 6
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should return <FolderCount> for parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $FolderCount)
+                ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count | Should -BeExactly $FolderCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $FolderCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+        Context 'Unit tests with existing custom windows credential' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=@{username='';password=''};AuthType="WindowsCustom"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return 6 Folders when no parameters are used' {
+                (Get-PasswordStateFolder).Count | Should -BeExactly 6
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should return <FolderCount> for parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $FolderCount)
+                ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count | Should -BeExactly $FolderCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $FolderCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
         Context 'Unit tests for winapi' {
             BeforeAll {
                 Set-PasswordStateEnvironment -path 'TestDrive:' -Baseuri $BaseURI -WindowsAuthOnly

--- a/tests/functions/Get-PasswordStateFolder.Tests.ps1
+++ b/tests/functions/Get-PasswordStateFolder.Tests.ps1
@@ -4,26 +4,26 @@ Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStateFolder" {
         BeforeAll {
-            $FunctionName='Get-PasswordStateFolder'
-            $BaseURI='https://passwordstate.local'
-            $APIKey='SuperSecretKey'
-            $TestCredential=[pscredential]::new('myuser',(ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
-            $ParameterSetCases=@(
-                 @{parametername='FolderName';mandatory='False';testvalue="Active Directory"}
-                ,@{parametername='Description';mandatory='False';testvalue="Root"}
-                ,@{parametername='TreePath';mandatory='False';testvalue="\RootFolder\Oracle"}
-                ,@{parametername='SiteID';mandatory='False';testvalue="1"}
-                ,@{parametername='SiteLocation';mandatory='False';testvalue="0"}
-                ,@{parametername='PreventAuditing';mandatory='False'}
+            $FunctionName = 'Get-PasswordStateFolder'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'FolderName'; mandatory = 'False'; testvalue = "Active Directory" }
+                , @{parametername = 'Description'; mandatory = 'False'; testvalue = "Root" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; testvalue = "\RootFolder\Oracle" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; testvalue = "1" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; testvalue = "0" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False' }
             )
-            $ParameterValues=@(
-                 @{parametername='FolderName';testvalue="Active Directory";FolderCount=1}
-                ,@{parametername='Description';testvalue="Root";FolderCount=1}
-                ,@{parametername='TreePath';testvalue="\\RootFolder\\Oracle";FolderCount=1}
+            $ParameterValues = @(
+                @{parametername = 'FolderName'; testvalue = "Active Directory"; FolderCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Root"; FolderCount = 1 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Oracle"; FolderCount = 1 }
             )
-            $SiteValues=@(
-                @{parametername='SiteID';FolderCount=6}
-                ,@{parametername='SiteLocation';FolderCount=6}
+            $SiteValues = @(
+                @{parametername = 'SiteID'; FolderCount = 6 }
+                , @{parametername = 'SiteLocation'; FolderCount = 6 }
             )
 
             # This Mock should never be hit, it is just to prevent actual calls from being executed and get annoying results
@@ -61,9 +61,65 @@ InModuleScope 'Passwordstate-Management' {
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).Mandatory)" | Should -be $mandatory
             }
         }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateFolder" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateFolder'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'FolderName'; mandatory = 'False'; testvalue = "Active Directory" }
+                , @{parametername = 'Description'; mandatory = 'False'; testvalue = "Root" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; testvalue = "\RootFolder\Oracle" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; testvalue = "1" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; testvalue = "0" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False' }
+            )
+            $ParameterValues = @(
+                @{parametername = 'FolderName'; testvalue = "Active Directory"; FolderCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Root"; FolderCount = 1 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Oracle"; FolderCount = 1 }
+            )
+            $SiteValues = @(
+                @{parametername = 'SiteID'; FolderCount = 6 }
+                , @{parametername = 'SiteLocation'; FolderCount = 6 }
+            )
+
+            # This Mock should never be hit, it is just to prevent actual calls from being executed and get annoying results
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchResponse']
+            } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchFolderNameResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?FolderName=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?Description=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?TreePath=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteID=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteLocation=[^\$]+$' } -Verifiable
+        }
         Context 'Unit tests with existing apikey profile' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=$APIKey;AuthType="APIKey"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = $APIKey; AuthType = "APIKey"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -80,17 +136,73 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $FolderCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateFolder" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateFolder'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'FolderName'; mandatory = 'False'; testvalue = "Active Directory" }
+                , @{parametername = 'Description'; mandatory = 'False'; testvalue = "Root" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; testvalue = "\RootFolder\Oracle" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; testvalue = "1" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; testvalue = "0" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False' }
+            )
+            $ParameterValues = @(
+                @{parametername = 'FolderName'; testvalue = "Active Directory"; FolderCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Root"; FolderCount = 1 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Oracle"; FolderCount = 1 }
+            )
+            $SiteValues = @(
+                @{parametername = 'SiteID'; FolderCount = 6 }
+                , @{parametername = 'SiteLocation'; FolderCount = 6 }
+            )
+
+            # This Mock should never be hit, it is just to prevent actual calls from being executed and get annoying results
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchResponse']
+            } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchFolderNameResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?FolderName=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?Description=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?TreePath=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteID=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteLocation=[^\$]+$' } -Verifiable
         }
         Context 'Unit tests with existing winapi profile' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey="";AuthType="WindowsIntegrated"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ""; AuthType = "WindowsIntegrated"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -107,7 +219,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $FolderCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
@@ -115,9 +227,65 @@ InModuleScope 'Passwordstate-Management' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
         }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateFolder" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateFolder'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'FolderName'; mandatory = 'False'; testvalue = "Active Directory" }
+                , @{parametername = 'Description'; mandatory = 'False'; testvalue = "Root" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; testvalue = "\RootFolder\Oracle" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; testvalue = "1" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; testvalue = "0" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False' }
+            )
+            $ParameterValues = @(
+                @{parametername = 'FolderName'; testvalue = "Active Directory"; FolderCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Root"; FolderCount = 1 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Oracle"; FolderCount = 1 }
+            )
+            $SiteValues = @(
+                @{parametername = 'SiteID'; FolderCount = 6 }
+                , @{parametername = 'SiteLocation'; FolderCount = 6 }
+            )
+
+            # This Mock should never be hit, it is just to prevent actual calls from being executed and get annoying results
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchResponse']
+            } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchFolderNameResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?FolderName=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?Description=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?TreePath=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteID=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteLocation=[^\$]+$' } -Verifiable
+        }
         Context 'Unit tests with existing custom windows credential' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=@{username='';password=''};AuthType="WindowsCustom"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = @{username = ''; password = '' }; AuthType = "WindowsCustom"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -134,13 +302,69 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $FolderCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateFolder" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateFolder'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'FolderName'; mandatory = 'False'; testvalue = "Active Directory" }
+                , @{parametername = 'Description'; mandatory = 'False'; testvalue = "Root" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; testvalue = "\RootFolder\Oracle" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; testvalue = "1" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; testvalue = "0" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False' }
+            )
+            $ParameterValues = @(
+                @{parametername = 'FolderName'; testvalue = "Active Directory"; FolderCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Root"; FolderCount = 1 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Oracle"; FolderCount = 1 }
+            )
+            $SiteValues = @(
+                @{parametername = 'SiteID'; FolderCount = 6 }
+                , @{parametername = 'SiteLocation'; FolderCount = 6 }
+            )
+
+            # This Mock should never be hit, it is just to prevent actual calls from being executed and get annoying results
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchResponse']
+            } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchFolderNameResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?FolderName=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?Description=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?TreePath=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteID=[^\$]+$' } -Verifiable
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['FolderSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/folders\/\?SiteLocation=[^\$]+$' } -Verifiable
         }
         Context 'Unit tests for winapi' {
             BeforeAll {
@@ -161,7 +385,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $FolderCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
@@ -188,7 +412,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $FolderCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
@@ -215,7 +439,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $FolderCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }

--- a/tests/functions/Get-PasswordStateHost.Tests.ps1
+++ b/tests/functions/Get-PasswordStateHost.Tests.ps1
@@ -69,6 +69,105 @@ InModuleScope 'Passwordstate-Management' {
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).Mandatory)" | Should -be $mandatory
             }
         }
+        Context 'Unit tests with existing winapi' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey="";AuthType="WindowsIntegrated"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return 6 hosts when no parameters are used' {
+                (Get-PasswordStateHost).Count | Should -BeExactly 6
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should return <ResultCount> host(s) when using parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ResultCount)
+                ((Invoke-Expression -Command "$($FunctionName) -$($parametername) '$($testvalue)'" ) | Measure-Object).Count | Should -BeExactly $ResultCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ResultCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                foreach ($ReturnValue in $TestValues) {
+                    $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should throw when Passwordstate returns an error' {
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+        Context 'Unit tests with existing custom credential' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=@{username='';password=''};AuthType="WindowsCustom"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return 6 hosts when no parameters are used' {
+                (Get-PasswordStateHost).Count | Should -BeExactly 6
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should return <ResultCount> host(s) when using parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ResultCount)
+                ((Invoke-Expression -Command "$($FunctionName) -$($parametername) '$($testvalue)'" ) | Measure-Object).Count | Should -BeExactly $ResultCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ResultCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                foreach ($ReturnValue in $TestValues) {
+                    $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should throw when Passwordstate returns an error' {
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+        Context 'Unit tests with existing apiKey' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=$APIKey;AuthType="APIKey"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return 6 hosts when no parameters are used' {
+                (Get-PasswordStateHost).Count | Should -BeExactly 6
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+
+            It 'Should return <ResultCount> host(s) when using parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ResultCount)
+                ((Invoke-Expression -Command "$($FunctionName) -$($parametername) '$($testvalue)'" ) | Measure-Object).Count | Should -BeExactly $ResultCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ResultCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                foreach ($ReturnValue in $TestValues) {
+                    $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should throw when Passwordstate returns an error' {
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
         Context 'Unit tests for winapi' {
             BeforeAll {
                 Set-PasswordStateEnvironment -path 'TestDrive:' -Baseuri $BaseURI -WindowsAuthOnly

--- a/tests/functions/Get-PasswordStateHost.Tests.ps1
+++ b/tests/functions/Get-PasswordStateHost.Tests.ps1
@@ -4,27 +4,27 @@ Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStateList" {
         BeforeAll {
-            $FunctionName='Get-PasswordStateHost'
-            $BaseURI='https://passwordstate.local'
-            $APIKey='SuperSecretKey'
-            $BadHostName='NonExistentHost'
-            $TestCredential=[pscredential]::new('myuser',(ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
-            $ParameterSetCases=@(
-                 @{parametername='HostName';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='HostType';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='OperatingSystem';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='DatabaseServerType';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='SiteID';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='SiteLocation';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='PreventAuditing';mandatory='False';ParameterSetName="__AllParameterSets"}
+            $FunctionName = 'Get-PasswordStateHost'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $BadHostName = 'NonExistentHost'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'HostType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'OperatingSystem'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'DatabaseServerType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
             )
-            $ParameterValues=@(
-                ,@{parametername='HostName';testvalue="my.local.host";ResultCount=1}
-                ,@{parametername='HostType';testvalue="Windows";ResultCount=2}
-                ,@{parametername='Operatingsystem';testvalue="Windows Server 2012";ResultCount=4}
-                ,@{parametername='DatabaseServerType';testvalue="mssql";ResultCount=5}
-                ,@{parametername='SiteID';testvalue="0";ResultCount=6}
-                ,@{parametername='SiteLocation';testvalue="Work";ResultCount=6}
+            $ParameterValues = @(
+                , @{parametername = 'HostName'; testvalue = "my.local.host"; ResultCount = 1 }
+                , @{parametername = 'HostType'; testvalue = "Windows"; ResultCount = 2 }
+                , @{parametername = 'Operatingsystem'; testvalue = "Windows Server 2012"; ResultCount = 4 }
+                , @{parametername = 'DatabaseServerType'; testvalue = "mssql"; ResultCount = 5 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ResultCount = 6 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ResultCount = 6 }
             )
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
@@ -33,31 +33,31 @@ InModuleScope 'Passwordstate-Management' {
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['HostSearchHostName']
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 throw "oepsie"
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=NonExistentHost$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=NonExistentHost$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['HostSearchHostType']
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostType=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostType=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['HostSearchOperatingsystem']
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?Operatingsystem=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?Operatingsystem=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['HostSearchDatabaseServerType']
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?DatabaseServerType=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?DatabaseServerType=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['HostSearchSiteID']
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteID=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteID=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['HostSearchSiteLocation']
-            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteLocation=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteLocation=[^\&]+$' }
         }
         Context 'Parameter Validation' {
             It 'should verify if parameter "<parametername>" is present' -TestCases $ParameterSetCases {
@@ -68,10 +68,71 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $mandatory)
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).Mandatory)" | Should -be $mandatory
             }
+        } } }
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateHost'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $BadHostName = 'NonExistentHost'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'HostType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'OperatingSystem'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'DatabaseServerType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                , @{parametername = 'HostName'; testvalue = "my.local.host"; ResultCount = 1 }
+                , @{parametername = 'HostType'; testvalue = "Windows"; ResultCount = 2 }
+                , @{parametername = 'Operatingsystem'; testvalue = "Windows Server 2012"; ResultCount = 4 }
+                , @{parametername = 'DatabaseServerType'; testvalue = "mssql"; ResultCount = 5 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ResultCount = 6 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ResultCount = 6 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearch']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostName']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                throw "oepsie"
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=NonExistentHost$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchOperatingsystem']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?Operatingsystem=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchDatabaseServerType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?DatabaseServerType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteID']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteLocation']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteLocation=[^\&]+$' }
         }
         Context 'Unit tests with existing winapi' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey="";AuthType="WindowsIntegrated"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ""; AuthType = "WindowsIntegrated"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -88,23 +149,87 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ResultCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ReturnValue in $TestValues) {
                     $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
                 }
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should throw when Passwordstate returns an error' {
-                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'" } | Should -Throw
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateHost'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $BadHostName = 'NonExistentHost'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'HostType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'OperatingSystem'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'DatabaseServerType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                , @{parametername = 'HostName'; testvalue = "my.local.host"; ResultCount = 1 }
+                , @{parametername = 'HostType'; testvalue = "Windows"; ResultCount = 2 }
+                , @{parametername = 'Operatingsystem'; testvalue = "Windows Server 2012"; ResultCount = 4 }
+                , @{parametername = 'DatabaseServerType'; testvalue = "mssql"; ResultCount = 5 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ResultCount = 6 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ResultCount = 6 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearch']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostName']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                throw "oepsie"
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=NonExistentHost$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchOperatingsystem']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?Operatingsystem=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchDatabaseServerType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?DatabaseServerType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteID']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteLocation']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteLocation=[^\&]+$' }
         }
         Context 'Unit tests with existing custom credential' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=@{username='';password=''};AuthType="WindowsCustom"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = @{username = ''; password = '' }; AuthType = "WindowsCustom"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -121,23 +246,87 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ResultCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ReturnValue in $TestValues) {
                     $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
                 }
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should throw when Passwordstate returns an error' {
-                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'" } | Should -Throw
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
         }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateHost'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $BadHostName = 'NonExistentHost'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'HostType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'OperatingSystem'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'DatabaseServerType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                , @{parametername = 'HostName'; testvalue = "my.local.host"; ResultCount = 1 }
+                , @{parametername = 'HostType'; testvalue = "Windows"; ResultCount = 2 }
+                , @{parametername = 'Operatingsystem'; testvalue = "Windows Server 2012"; ResultCount = 4 }
+                , @{parametername = 'DatabaseServerType'; testvalue = "mssql"; ResultCount = 5 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ResultCount = 6 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ResultCount = 6 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearch']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostName']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                throw "oepsie"
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=NonExistentHost$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchOperatingsystem']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?Operatingsystem=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchDatabaseServerType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?DatabaseServerType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteID']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteLocation']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteLocation=[^\&]+$' }
+        }
         Context 'Unit tests with existing apiKey' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=$APIKey;AuthType="APIKey"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = $APIKey; AuthType = "APIKey"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -154,19 +343,83 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ResultCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ReturnValue in $TestValues) {
                     $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
                 }
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should throw when Passwordstate returns an error' {
-                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'" } | Should -Throw
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateHost'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $BadHostName = 'NonExistentHost'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $ParameterSetCases = @(
+                @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'HostType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'OperatingSystem'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'DatabaseServerType'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                , @{parametername = 'HostName'; testvalue = "my.local.host"; ResultCount = 1 }
+                , @{parametername = 'HostType'; testvalue = "Windows"; ResultCount = 2 }
+                , @{parametername = 'Operatingsystem'; testvalue = "Windows Server 2012"; ResultCount = 4 }
+                , @{parametername = 'DatabaseServerType'; testvalue = "mssql"; ResultCount = 5 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ResultCount = 6 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ResultCount = 6 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearch']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostName']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                throw "oepsie"
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostName=NonExistentHost$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchHostType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?HostType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchOperatingsystem']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?Operatingsystem=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchDatabaseServerType']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?DatabaseServerType=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteID']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['HostSearchSiteLocation']
+            } -ParameterFilter { $uri -and $uri -match '\/hosts\/\?SiteLocation=[^\&]+$' }
         }
         Context 'Unit tests for winapi' {
             BeforeAll {
@@ -187,14 +440,14 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ResultCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ReturnValue in $TestValues) {
                     $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
                 }
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should throw when Passwordstate returns an error' {
-                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'" } | Should -Throw
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
@@ -220,14 +473,14 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ResultCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ReturnValue in $TestValues) {
                     $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
                 }
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should throw when Passwordstate returns an error' {
-                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'" } | Should -Throw
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
@@ -253,14 +506,14 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ResultCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ReturnValue in $TestValues) {
                     $ReturnValue."$($ParameterName)" | Should -MatchExactly $testvalue
                 }
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should throw when Passwordstate returns an error' {
-                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'"} | Should -Throw
+                { Invoke-Expression -Command "$($FunctionName) -HostName '$($BadHostName)'" } | Should -Throw
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {

--- a/tests/functions/Get-PasswordStateList.Tests.ps1
+++ b/tests/functions/Get-PasswordStateList.Tests.ps1
@@ -4,27 +4,27 @@ Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 InModuleScope 'Passwordstate-Management' {
     Describe "Get-PasswordStateList" {
         BeforeAll {
-            $FunctionName='Get-PasswordStateList'
-            $BaseURI='https://passwordstate.local'
-            $APIKey='SuperSecretKey'
-            $TestCredential=[pscredential]::new('myuser',(ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
-            $PasswordListId=211
-            $ParameterSetCases=@(
-                 @{parametername='PasswordListID';mandatory='False';ParameterSetName="ID"}
-                ,@{parametername='PasswordList';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='Description';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='TreePath';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='SiteID';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='SiteLocation';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='PreventAuditing';mandatory='False';ParameterSetName="__AllParameterSets"}
+            $FunctionName = 'Get-PasswordStateList'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordListID'; mandatory = 'False'; ParameterSetName = "ID" }
+                , @{parametername = 'PasswordList'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
             )
-            $ParameterValues=@(
-                 @{parametername='';testvalue="";ListCount=8}
-                ,@{parametername='PasswordList';testvalue="AD User Accounts";ListCount=1}
-                ,@{parametername='Description';testvalue="Oracle Accounts";ListCount=2}
-                ,@{parametername='TreePath';testvalue="\\RootFolder\\Applications";ListCount=2}
-                ,@{parametername='SiteID';testvalue="0";ListCount=8}
-                ,@{parametername='SiteLocation';testvalue="Work";ListCount=4}
+            $ParameterValues = @(
+                @{parametername = ''; testvalue = ""; ListCount = 8 }
+                , @{parametername = 'PasswordList'; testvalue = "AD User Accounts"; ListCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Oracle Accounts"; ListCount = 2 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Applications"; ListCount = 2 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ListCount = 8 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ListCount = 4 }
             )
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
@@ -33,23 +33,23 @@ InModuleScope 'Passwordstate-Management' {
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['ListSearchPasswordListResponse']
-            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?PasswordList=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?PasswordList=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['ListSearchDescriptionResponse']
-            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?Description=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?Description=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['ListSearchTreePathResponse']
-            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?TreePath=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?TreePath=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['ListSearchSiteIDResponse']
-            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteID=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteID=[^\&]+$' }
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON['ListSearchSiteLocationResponse']
-            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteLocation=[^\&]+$'}
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteLocation=[^\&]+$' }
 
         }
         Context 'Parameter Validation' {
@@ -65,10 +65,64 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $parametersetname)
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).ParameterSetName)" | Should -be $ParameterSetName
             }
+        } } }
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateList'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordListID'; mandatory = 'False'; ParameterSetName = "ID" }
+                , @{parametername = 'PasswordList'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                @{parametername = ''; testvalue = ""; ListCount = 8 }
+                , @{parametername = 'PasswordList'; testvalue = "AD User Accounts"; ListCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Oracle Accounts"; ListCount = 2 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Applications"; ListCount = 2 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ListCount = 8 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ListCount = 4 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListResponse']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchPasswordListResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?PasswordList=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?Description=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?TreePath=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteLocation=[^\&]+$' }
+        
         }
         Context 'Unit tests with winapi profile' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey="";AuthType="WindowsIntegrated"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ""; AuthType = "WindowsIntegrated"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -85,17 +139,74 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ListCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateList'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordListID'; mandatory = 'False'; ParameterSetName = "ID" }
+                , @{parametername = 'PasswordList'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                @{parametername = ''; testvalue = ""; ListCount = 8 }
+                , @{parametername = 'PasswordList'; testvalue = "AD User Accounts"; ListCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Oracle Accounts"; ListCount = 2 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Applications"; ListCount = 2 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ListCount = 8 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ListCount = 4 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListResponse']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchPasswordListResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?PasswordList=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?Description=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?TreePath=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteLocation=[^\&]+$' }
+        
         }
         Context 'Unit tests with Custom credential profile' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=@{username='';password=''};AuthType="WindowsCustom"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = @{username = ''; password = '' }; AuthType = "WindowsCustom"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -112,7 +223,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ListCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
@@ -120,9 +231,66 @@ InModuleScope 'Passwordstate-Management' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
         }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateList'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordListID'; mandatory = 'False'; ParameterSetName = "ID" }
+                , @{parametername = 'PasswordList'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                @{parametername = ''; testvalue = ""; ListCount = 8 }
+                , @{parametername = 'PasswordList'; testvalue = "AD User Accounts"; ListCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Oracle Accounts"; ListCount = 2 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Applications"; ListCount = 2 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ListCount = 8 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ListCount = 4 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListResponse']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchPasswordListResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?PasswordList=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?Description=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?TreePath=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteLocation=[^\&]+$' }
+        
+        }
         Context 'Unit tests with APIKey profile' {
             BeforeAll {
-                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=$APIKey;AuthType="APIKey"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = $APIKey; AuthType = "APIKey"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
             }
             AfterAll {
                 Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -139,13 +307,70 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ListCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
             It 'Should have called function Get-PasswordStateResource' {
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource'
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStateList" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStateList'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordListID'; mandatory = 'False'; ParameterSetName = "ID" }
+                , @{parametername = 'PasswordList'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'TreePath'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterValues = @(
+                @{parametername = ''; testvalue = ""; ListCount = 8 }
+                , @{parametername = 'PasswordList'; testvalue = "AD User Accounts"; ListCount = 1 }
+                , @{parametername = 'Description'; testvalue = "Oracle Accounts"; ListCount = 2 }
+                , @{parametername = 'TreePath'; testvalue = "\\RootFolder\\Applications"; ListCount = 2 }
+                , @{parametername = 'SiteID'; testvalue = "0"; ListCount = 8 }
+                , @{parametername = 'SiteLocation'; testvalue = "Work"; ListCount = 4 }
+            )
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListResponse']
+            }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchPasswordListResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?PasswordList=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchDescriptionResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?Description=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchTreePathResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?TreePath=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteIDResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteID=[^\&]+$' }
+        
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON['ListSearchSiteLocationResponse']
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswordlists\/\?SiteLocation=[^\&]+$' }
+        
         }
         Context 'Unit tests for winapi' {
             BeforeAll {
@@ -166,7 +391,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ListCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
@@ -193,7 +418,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ListCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }
@@ -220,7 +445,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
                 param($parametername, $testvalue, $ListCount)
-                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $TestValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
                 Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
             }

--- a/tests/functions/Get-PasswordStateList.Tests.ps1
+++ b/tests/functions/Get-PasswordStateList.Tests.ps1
@@ -66,6 +66,87 @@ InModuleScope 'Passwordstate-Management' {
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).ParameterSetName)" | Should -be $ParameterSetName
             }
         }
+        Context 'Unit tests with winapi profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey="";AuthType="WindowsIntegrated"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return <ListCount> for parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ListCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+        Context 'Unit tests with Custom credential profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=@{username='';password=''};AuthType="WindowsCustom"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return <ListCount> for parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ListCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+        Context 'Unit tests with APIKey profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri=$BaseURI;Apikey=$APIKey;AuthType="APIKey"; TimeoutSeconds=60} | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return <ListCount> for parameter <parametername>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching <testvalue>' -TestCases $ParameterValues {
+                param($parametername, $testvalue, $ListCount)
+                $TestValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                ($TestValues | Select-Object -First 1)."$($ParameterName)" | Should -Match $testvalue
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
         Context 'Unit tests for winapi' {
             BeforeAll {
                 Set-PasswordStateEnvironment -path 'TestDrive:' -Baseuri $BaseURI -WindowsAuthOnly

--- a/tests/functions/Get-PasswordStatePassword.Tests.ps1
+++ b/tests/functions/Get-PasswordStatePassword.Tests.ps1
@@ -2,59 +2,59 @@ Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
 Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
 . "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
 InModuleScope 'Passwordstate-Management' {
-    Describe "Get-PasswordStateList" {
+    Describe "Get-PasswordStatePassword parameter validation" {
         BeforeAll {
-            $FunctionName='Get-PasswordStatePassword'
-            $BaseURI='https://passwordstate.local'
-            $APIKey='SuperSecretKey'
-            $TestCredential=[pscredential]::new('myuser',(ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
-            $PasswordListId=211
-            $ParameterSetCases=@(
-                 @{parametername='Search';mandatory='False';ParameterSetName="General"}
-                 @{parametername='Title';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='UserName';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='HostName';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='Domain';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='AccountType';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='Description';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='Notes';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='URL';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='SiteID';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='SiteLocation';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField1';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField2';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField3';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField4';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField5';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField6';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField7';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField8';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField9';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='GenericField10';mandatory='False';ParameterSetName="Specific"}
-                ,@{parametername='Reason';mandatory='False';ParameterSetName="__AllParameterSets"}
-                ,@{parametername='PreventAuditing';mandatory='False';ParameterSetName="__AllParameterSets"}
+            $FunctionName = 'Get-PasswordStatePassword'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = "General" }
+                @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
             )
-            $ParameterSpecificValues=@(
-                 @{parametername='Title';testvalue="Demo AD Username";ListCount=2;PWLID=53}
-                ,@{parametername='UserName';testvalue="username1";ListCount=3;PWLID=53}
-                ,@{parametername='HostName';testvalue="HostA";ListCount=4;PWLID=53}
-                ,@{parametername='Domain';testvalue="MYDomain";ListCount=5;PWLID=53}
-                ,@{parametername='AccountType';testvalue="";ListCount=1;PWLID=53} # testvalue must be empty because the actual property is AccountTypeID
-                ,@{parametername='Description';testvalue="Description for ";ListCount=6;PWLID=53}
-                ,@{parametername='Notes';testvalue="Same Notes";ListCount=7;PWLID=53}
-                ,@{parametername='URL';testvalue="https://passworstate.local";ListCount=8;PWLID=53}
-                ,@{parametername='SiteID';testvalue="";ListCount=9;PWLID=53}
-                ,@{parametername='SiteLocation';testvalue="";ListCount=11;PWLID=53}
-                ,@{parametername='GenericField1';testvalue="TestField1";ListCount=11;PWLID=53}
-                ,@{parametername='GenericField2';testvalue="TestField2";ListCount=12;PWLID=53}
-                ,@{parametername='GenericField3';testvalue="TestField3";ListCount=13;PWLID=53}
-                ,@{parametername='GenericField4';testvalue="TestField4";ListCount=14;PWLID=53}
-                ,@{parametername='GenericField5';testvalue="TestField5";ListCount=15;PWLID=53}
-                ,@{parametername='GenericField6';testvalue="TestField6";ListCount=16;PWLID=53}
-                ,@{parametername='GenericField7';testvalue="TestField7";ListCount=17;PWLID=53}
-                ,@{parametername='GenericField8';testvalue="TestField8";ListCount=18;PWLID=53}
-                ,@{parametername='GenericField9';testvalue="TestField9";ListCount=19;PWLID=53}
-                ,@{parametername='GenericField10';testvalue="TestField10";ListCount=20;PWLID=53}
+            $ParameterSpecificValues = @(
+                @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
+                , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
+                , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+                , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
+                , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
+                , @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
+                , @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
+                , @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
+                , @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
+                , @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
+                , @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
+                , @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
+                , @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
+                , @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
+                , @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
+                , @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
             )
 
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
@@ -62,7 +62,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             Mock -CommandName 'Get-PasswordStateResource' -MockWith {
                 $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
-            } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$'} -Verifiable
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
 
         }
         Context 'Parameter Validation' {
@@ -78,6 +78,460 @@ InModuleScope 'Passwordstate-Management' {
                 param($parametername, $parametersetname)
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).ParameterSetName)" | Should -be $ParameterSetName
             }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStatePassword with winapi profile" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePassword'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = "General" }
+                @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterSpecificValues = @(
+                @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
+                , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
+                , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+                , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
+                , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
+                , @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
+                , @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
+                , @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
+                , @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
+                , @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
+                , @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
+                , @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
+                , @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
+                , @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
+                , @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
+                , @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            )
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
+
+        }
+        Context 'Unit tests with winapi profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ""; AuthType = "WindowsIntegrated"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount, $PWLID)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount, $PWLID)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                foreach ($ResultValue in $ResultValues) {
+                    $ResultValue."$($ParameterName)" | Should -Match $testvalue
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+    }
+}
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStatePassword with Custom Credentials in profile" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePassword'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = "General" }
+                @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterSpecificValues = @(
+                @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
+                , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
+                , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+                , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
+                , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
+                , @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
+                , @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
+                , @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
+                , @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
+                , @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
+                , @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
+                , @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
+                , @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
+                , @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
+                , @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
+                , @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            )
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
+
+        }
+        Context 'Unit tests with Custom Credentials profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = @{username = ($TestCredential.username ) ; password = ($TestCredential.Password | ConvertFrom-SecureString ) }; AuthType = "WindowsCustom"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount, $PWLID)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount, $PWLID)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                foreach ($ResultValue in $ResultValues) {
+                    $ResultValue."$($ParameterName)" | Should -Match $testvalue
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+    }
+}
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStatePassword with apikey in profile" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePassword'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = "General" }
+                @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterSpecificValues = @(
+                @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
+                , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
+                , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+                , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
+                , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
+                , @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
+                , @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
+                , @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
+                , @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
+                , @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
+                , @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
+                , @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
+                , @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
+                , @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
+                , @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
+                , @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            )
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
+
+        }
+        Context 'Unit tests with apiKey profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ($APIKey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString ); AuthType = "APIKey"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should return <ListCount> for parameter <parametername> without PasswordListID' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID>' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount, $PWLID)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> without PasswordListID and PreventAudit set to True' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)' -PreventAuditing:`$True" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return <ListCount> for parameter <parametername> with PasswordListID <PWLID> and PreventAudit set to True' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount, $PWLID)
+                $Result = if ($parametername -ne '') {
+                    ((Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'" ) | Measure-Object).Count
+                } else {
+                    ((Invoke-Expression -Command "$($FunctionName)" ) | Measure-Object).Count
+                }
+                $Result | Should -BeExactly $ListCount
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterSpecificValues {
+                param($parametername, $testvalue, $ListCount)
+                $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                foreach ($ResultValue in $ResultValues) {
+                    $ResultValue."$($ParameterName)" | Should -Match $testvalue
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+    }
+}
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope 'Passwordstate-Management' {
+    Describe "Get-PasswordStatePassword for winapi" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePassword'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $ParameterSetCases = @(
+                @{parametername = 'Search'; mandatory = 'False'; ParameterSetName = "General" }
+                @{parametername = 'Title'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'UserName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'HostName'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Domain'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'AccountType'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Description'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Notes'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'URL'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteID'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'SiteLocation'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField1'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField2'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField3'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField4'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField5'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField6'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField7'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField8'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField9'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'GenericField10'; mandatory = 'False'; ParameterSetName = "Specific" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            $ParameterSpecificValues = @(
+                @{parametername = 'Title'; testvalue = "Demo AD Username"; ListCount = 2; PWLID = 53 }
+                , @{parametername = 'UserName'; testvalue = "username1"; ListCount = 3; PWLID = 53 }
+                , @{parametername = 'HostName'; testvalue = "HostA"; ListCount = 4; PWLID = 53 }
+                , @{parametername = 'Domain'; testvalue = "MYDomain"; ListCount = 5; PWLID = 53 }
+                , @{parametername = 'AccountType'; testvalue = ""; ListCount = 1; PWLID = 53 } # testvalue must be empty because the actual property is AccountTypeID
+                , @{parametername = 'Description'; testvalue = "Description for "; ListCount = 6; PWLID = 53 }
+                , @{parametername = 'Notes'; testvalue = "Same Notes"; ListCount = 7; PWLID = 53 }
+                , @{parametername = 'URL'; testvalue = "https://passworstate.local"; ListCount = 8; PWLID = 53 }
+                , @{parametername = 'SiteID'; testvalue = ""; ListCount = 9; PWLID = 53 }
+                , @{parametername = 'SiteLocation'; testvalue = ""; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField1'; testvalue = "TestField1"; ListCount = 11; PWLID = 53 }
+                , @{parametername = 'GenericField2'; testvalue = "TestField2"; ListCount = 12; PWLID = 53 }
+                , @{parametername = 'GenericField3'; testvalue = "TestField3"; ListCount = 13; PWLID = 53 }
+                , @{parametername = 'GenericField4'; testvalue = "TestField4"; ListCount = 14; PWLID = 53 }
+                , @{parametername = 'GenericField5'; testvalue = "TestField5"; ListCount = 15; PWLID = 53 }
+                , @{parametername = 'GenericField6'; testvalue = "TestField6"; ListCount = 16; PWLID = 53 }
+                , @{parametername = 'GenericField7'; testvalue = "TestField7"; ListCount = 17; PWLID = 53 }
+                , @{parametername = 'GenericField8'; testvalue = "TestField8"; ListCount = 18; PWLID = 53 }
+                , @{parametername = 'GenericField9'; testvalue = "TestField9"; ListCount = 19; PWLID = 53 }
+                , @{parametername = 'GenericField10'; testvalue = "TestField10"; ListCount = 20; PWLID = 53 }
+            )
+
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordSearch$($ParameterName)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/searchpasswords\/(\d+){0,1}\?\w+=[^\&]+$' } -Verifiable
+
         }
         Context 'Unit tests for winapi' {
             BeforeAll {
@@ -128,7 +582,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterSpecificValues {
                 param($parametername, $testvalue, $ListCount)
-                $ResultValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ResultValue in $ResultValues) {
                     $ResultValue."$($ParameterName)" | Should -Match $testvalue
                 }
@@ -187,7 +641,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterSpecificValues {
                 param($parametername, $testvalue, $ListCount)
-                $ResultValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ResultValue in $ResultValues) {
                     $ResultValue."$($ParameterName)" | Should -Match $testvalue
                 }
@@ -199,7 +653,7 @@ InModuleScope 'Passwordstate-Management' {
         }
         Context 'Unit tests for apiKey' {
             BeforeAll {
-                Set-PasswordStateEnvironment -path 'TestDrive:' -Baseuri $BaseURI -Apikey $APIKey
+                Set-PasswordStateEnvironment -path 'TestDrive:' -Uri $BaseURI -Apikey $APIKey
             }
             AfterAll {
                 Remove-Item -Path 'TestDrive:\Passwordstate.json' -Force -Confirm:$false -ErrorAction SilentlyContinue
@@ -246,7 +700,7 @@ InModuleScope 'Passwordstate-Management' {
             }
             It 'Should have a <parametername> matching "<testvalue>"' -TestCases $ParameterSpecificValues {
                 param($parametername, $testvalue, $ListCount)
-                $ResultValues=Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
+                $ResultValues = Invoke-Expression -Command "$($FunctionName) -$($Parametername) '$($testvalue)'"
                 foreach ($ResultValue in $ResultValues) {
                     $ResultValue."$($ParameterName)" | Should -Match $testvalue
                 }

--- a/tests/functions/Get-PasswordStatePasswordHistory.Tests.ps1
+++ b/tests/functions/Get-PasswordStatePasswordHistory.Tests.ps1
@@ -45,6 +45,231 @@ InModuleScope -ModuleName 'PasswordState-Management' {
                 "$(((Get-Command -Name $FunctionName).Parameters[$parametername].Attributes | Where-Object { $_.GetType().fullname -eq 'System.Management.Automation.ParameterAttribute'}).ParameterSetName)" | Should -be $ParameterSetName
             }
         }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope -ModuleName 'PasswordState-Management' {
+    Describe "Get-PasswordStatePasswordHistory" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePasswordHistory'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $RightPasswordID = 9568
+            $WrongPasswordID = 999
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordID'; mandatory = 'True'; ParameterSetName="__AllParameterSets" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordHistoryResponse"]
+            }
+
+            Mock -CommandName 'Get-PasswordStateResource' -Verifiable -MockWith {
+                $Global:TestJSON["PasswordHistory$($PasswordID)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/passwordhistory\/\d+' }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Details = [System.Management.Automation.ErrorDetails]::new('[{"errors":[{"message":"Not Found"},{"phrase":"A Password of ID ''999'' was not found in the database, or you do not have permissions to it."}]}]')
+                $WebException=([System.Net.WebException]::new('{"errors":{"phrase":"ikke"}}',[system.net.webexceptionstatus]::protocolerror))
+                $ErrorRecord = [System.Management.Automation.ErrorRecord]::new($WebException,'',[System.Management.Automation.ErrorCategory]::ObjectNotFound, $null)
+                $ErrorRecord.ErrorDetails = $Details
+                throw $ErrorRecord
+            } -ParameterFilter { $uri -and $uri -match "\/passwordhistory\/999" } -Verifiable
+        }
+        Context 'Unit tests with winapi profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ""; AuthType = "WindowsIntegrated"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should throw when PasswordID does not exist' {
+                { (Invoke-Expression -Command "$($FunctionName) -PasswordID $($WrongPasswordID)") } | should -Throw
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return error with a specific error message' {
+                try {
+                    (Invoke-Expression -Command "$($FunctionName) -PasswordID $($WrongPasswordID)" -ErrorAction Stop)
+                }
+                catch [system.exception] {
+                    "$($_.exception)" | Should -MatchExactly "A Password of ID '$($WrongPasswordID)' was not found in the database, or you do not have permissions to it."
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return 2 history items for an existing passwordID' {
+                (( Invoke-Expression -Command "$($FunctionName) -PasswordID $($RightPasswordID)") | Measure-Object).Count | Should -be 2
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope -ModuleName 'PasswordState-Management' {
+    Describe "Get-PasswordStatePasswordHistory" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePasswordHistory'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $RightPasswordID = 9568
+            $WrongPasswordID = 999
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordID'; mandatory = 'True'; ParameterSetName="__AllParameterSets" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordHistoryResponse"]
+            }
+
+            Mock -CommandName 'Get-PasswordStateResource' -Verifiable -MockWith {
+                $Global:TestJSON["PasswordHistory$($PasswordID)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/passwordhistory\/\d+' }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Details = [System.Management.Automation.ErrorDetails]::new('[{"errors":[{"message":"Not Found"},{"phrase":"A Password of ID ''999'' was not found in the database, or you do not have permissions to it."}]}]')
+                $WebException=([System.Net.WebException]::new('{"errors":{"phrase":"ikke"}}',[system.net.webexceptionstatus]::protocolerror))
+                $ErrorRecord = [System.Management.Automation.ErrorRecord]::new($WebException,'',[System.Management.Automation.ErrorCategory]::ObjectNotFound, $null)
+                $ErrorRecord.ErrorDetails = $Details
+                throw $ErrorRecord
+            } -ParameterFilter { $uri -and $uri -match "\/passwordhistory\/999" } -Verifiable
+        }
+        Context 'Unit tests with Custom Credentials profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = @{username = ($TestCredential.username ) ; password = ($TestCredential.Password | ConvertFrom-SecureString ) }; AuthType = "WindowsCustom"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should throw when PasswordID does not exist' {
+                { (Invoke-Expression -Command "$($FunctionName) -PasswordID $($WrongPasswordID)") } | should -Throw
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return error with a specific error message' {
+                try {
+                    (Invoke-Expression -Command "$($FunctionName) -PasswordID $($WrongPasswordID)" -ErrorAction Stop)
+                }
+                catch [system.exception] {
+                    "$($_.exception)" | Should -MatchExactly "A Password of ID '$($WrongPasswordID)' was not found in the database, or you do not have permissions to it."
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return 2 history items for an existing passwordID' {
+                (( Invoke-Expression -Command "$($FunctionName) -PasswordID $($RightPasswordID)") | Measure-Object).Count | Should -be 2
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope -ModuleName 'PasswordState-Management' {
+    Describe "Get-PasswordStatePasswordHistory" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePasswordHistory'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $RightPasswordID = 9568
+            $WrongPasswordID = 999
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordID'; mandatory = 'True'; ParameterSetName="__AllParameterSets" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordHistoryResponse"]
+            }
+
+            Mock -CommandName 'Get-PasswordStateResource' -Verifiable -MockWith {
+                $Global:TestJSON["PasswordHistory$($PasswordID)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/passwordhistory\/\d+' }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Details = [System.Management.Automation.ErrorDetails]::new('[{"errors":[{"message":"Not Found"},{"phrase":"A Password of ID ''999'' was not found in the database, or you do not have permissions to it."}]}]')
+                $WebException=([System.Net.WebException]::new('{"errors":{"phrase":"ikke"}}',[system.net.webexceptionstatus]::protocolerror))
+                $ErrorRecord = [System.Management.Automation.ErrorRecord]::new($WebException,'',[System.Management.Automation.ErrorCategory]::ObjectNotFound, $null)
+                $ErrorRecord.ErrorDetails = $Details
+                throw $ErrorRecord
+            } -ParameterFilter { $uri -and $uri -match "\/passwordhistory\/999" } -Verifiable
+        }
+        Context 'Unit tests with apiKey profile' {
+            BeforeAll {
+                Set-Content -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Value (@{Baseuri = $BaseURI; Apikey = ($APIKey | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString ); AuthType = "APIKey"; TimeoutSeconds = 60 } | ConvertTo-Json) -Force -Confirm:$false
+            }
+            AfterAll {
+                Remove-Item -Path "$([environment]::GetFolderPath("UserProfile"))\Passwordstate.json" -Force -Confirm:$false -ErrorAction SilentlyContinue
+            }
+            It 'Should throw when PasswordID does not exist' {
+                { (Invoke-Expression -Command "$($FunctionName) -PasswordID $($WrongPasswordID)") } | should -Throw
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return error with a specific error message' {
+                try {
+                    (Invoke-Expression -Command "$($FunctionName) -PasswordID $($WrongPasswordID)" -ErrorAction Stop)
+                }
+                catch [system.exception] {
+                    "$($_.exception)" | Should -MatchExactly "A Password of ID '$($WrongPasswordID)' was not found in the database, or you do not have permissions to it."
+                }
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource' -Exactly -Times 1 -Scope It
+            }
+            It 'Should return 2 history items for an existing passwordID' {
+                (( Invoke-Expression -Command "$($FunctionName) -PasswordID $($RightPasswordID)") | Measure-Object).Count | Should -be 2
+            }
+            It 'Should have called function Get-PasswordStateResource' {
+                Assert-MockCalled -CommandName 'Get-PasswordStateResource'
+            }
+        }
+    }
+}
+
+Remove-Module PasswordState-Management -Force -ErrorAction SilentlyContinue
+Import-module "$($PSScriptRoot)\..\..\Passwordstate-management.psd1" -Force
+. "$($PSScriptRoot)\json\enum-jsonFiles.ps1"
+InModuleScope -ModuleName 'PasswordState-Management' {
+    Describe "Get-PasswordStatePasswordHistory" {
+        BeforeAll {
+            $FunctionName = 'Get-PasswordStatePasswordHistory'
+            $BaseURI = 'https://passwordstate.local'
+            $APIKey = 'SuperSecretKey'
+            $TestCredential = [pscredential]::new('myuser', (ConvertTo-SecureString -AsPlainText -Force -String $APIKey))
+            $PasswordListId = 211
+            $RightPasswordID = 9568
+            $WrongPasswordID = 999
+            $ParameterSetCases = @(
+                @{parametername = 'PasswordID'; mandatory = 'True'; ParameterSetName="__AllParameterSets" }
+                , @{parametername = 'Reason'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+                , @{parametername = 'PreventAuditing'; mandatory = 'False'; ParameterSetName = "__AllParameterSets" }
+            )
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Global:TestJSON["PasswordHistoryResponse"]
+            }
+
+            Mock -CommandName 'Get-PasswordStateResource' -Verifiable -MockWith {
+                $Global:TestJSON["PasswordHistory$($PasswordID)Response"]
+            } -ParameterFilter { $uri -and $uri -match '\/passwordhistory\/\d+' }
+            Mock -CommandName 'Get-PasswordStateResource' -MockWith {
+                $Details = [System.Management.Automation.ErrorDetails]::new('[{"errors":[{"message":"Not Found"},{"phrase":"A Password of ID ''999'' was not found in the database, or you do not have permissions to it."}]}]')
+                $WebException=([System.Net.WebException]::new('{"errors":{"phrase":"ikke"}}',[system.net.webexceptionstatus]::protocolerror))
+                $ErrorRecord = [System.Management.Automation.ErrorRecord]::new($WebException,'',[System.Management.Automation.ErrorCategory]::ObjectNotFound, $null)
+                $ErrorRecord.ErrorDetails = $Details
+                throw $ErrorRecord
+            } -ParameterFilter { $uri -and $uri -match "\/passwordhistory\/999" } -Verifiable
+        }
         Context 'Unit tests for winapi' {
             BeforeAll {
                 Set-PasswordStateEnvironment -path 'TestDrive:' -Baseuri $BaseURI -WindowsAuthOnly

--- a/tests/pester.ps1
+++ b/tests/pester.ps1
@@ -56,7 +56,11 @@ if ($TestGeneral)
 #region Test Commands
 if ($TestFunctions)
 {
-Write-PSFMessage -Level Important -Message "Proceeding with individual tests"
+	Write-PSFMessage -Level Important -Message "Proceeding with individual tests"
+	if (Test-Path -Path "$([System.Environment]::GetFolderPath("UserProfile"))\passwordstate.json") {
+		Write-PSFMessage -Level Important -Message "Profile passwordstate json exists: renaming to prevent false test results"
+		Rename-Item -Path "$([System.Environment]::GetFolderPath("UserProfile"))\passwordstate.json" -NewName "$([System.Environment]::GetFolderPath("UserProfile"))\replace_passwordstate.json" -Force -Confirm:$false
+	}
 	foreach ($file in (Get-ChildItem "$PSScriptRoot\functions" -Recurse -File | Where-Object Name -like "*Tests.ps1"))
 	{
 		if ($file.Name -notlike $Include) { continue }
@@ -79,6 +83,10 @@ Write-PSFMessage -Level Important -Message "Proceeding with individual tests"
 				}
 			}
 		}
+	}
+	if (Test-Path -Path "$([System.Environment]::GetFolderPath("UserProfile"))\replace_passwordstate.json") {
+		Write-PSFMessage -Level Important -Message "Restoring Profile passwordstate json exists"
+		Rename-Item -Path "$([System.Environment]::GetFolderPath("UserProfile"))\replace_passwordstate.json" -NewName "$([System.Environment]::GetFolderPath("UserProfile"))\passwordstate.json" -Force -Confirm:$false
 	}
 }
 #endregion Test Commands


### PR DESCRIPTION
Update tests files so they work with and without passwordstate.json presence in the user profile.
If the file is present, it will be renamed during pester tests.